### PR TITLE
Types writing optimization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,14 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-//        classpath 'me.champeau.gradle:jmh-gradle-plugin:latest.release'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:latest.release'
         classpath 'org.junit.platform:junit-platform-gradle-plugin:latest.release'
         classpath 'com.netflix.nebula:nebula-project-plugin:latest.release'
     }
 }
 
 apply plugin: 'java'
+apply plugin: "me.champeau.gradle.jmh"
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 repositories {
@@ -33,6 +34,11 @@ dependencies {
     compile group: 'org.jctools', name: 'jctools-core', version: '2.1.2'
     compile group: 'org.lz4', name: 'lz4-java', version: '1.4.1'
     compile group: 'com.github.luben', name: 'zstd-jni', version: '1.3.3-4'
+}
+
+dependencies {
+    jmh 'org.openjdk.jmh:jmh-core:latest.release'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess:latest.release'
 }
 
 dependencies {

--- a/src/jmh/java/com/github/mangelion/ColumnTypeBenchmarks.java
+++ b/src/jmh/java/com/github/mangelion/ColumnTypeBenchmarks.java
@@ -26,8 +26,8 @@ import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static org.openjdk.jmh.annotations.Mode.Throughput;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
 
 /**
  * @author Camelion
@@ -37,8 +37,8 @@ import static org.openjdk.jmh.annotations.Mode.Throughput;
  * and performance will be slightly better with manual switch case
  */
 @Fork(value = 1, jvmArgs = {"-server"/*, "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintAssembly"*/})
-@BenchmarkMode(Throughput)
-@OutputTimeUnit(MICROSECONDS)
+@BenchmarkMode(AverageTime)
+@OutputTimeUnit(NANOSECONDS)
 @Warmup(iterations = 5)
 @Measurement(iterations = 5)
 @State(Scope.Benchmark)
@@ -117,6 +117,16 @@ public class ColumnTypeBenchmarks {
             void consume(Object o, Blackhole bh) {
                 bh.consume((int) o);
             }
+        }, E_CONSUMER_7 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        }, E_CONSUMER_8 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
         };
 
 
@@ -143,6 +153,15 @@ public class ColumnTypeBenchmarks {
                     return;
                 case 6:
                     consume6(o, bh);
+                    return;
+                case 7:
+                    consume7(o, bh);
+                    return;
+                case 8:
+                    consume8(o, bh);
+                    return;
+                default:
+                    throw new IllegalArgumentException("Can not write unknown type " + type);
             }
         }
 
@@ -167,6 +186,14 @@ public class ColumnTypeBenchmarks {
         }
 
         static void consume6(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume7(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume8(Object o, Blackhole bh) {
             bh.consume((int) o);
         }
     }

--- a/src/jmh/java/com/github/mangelion/ColumnTypeBenchmarks.java
+++ b/src/jmh/java/com/github/mangelion/ColumnTypeBenchmarks.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2017-2018 Mangelion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.mangelion;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.openjdk.jmh.annotations.Mode.Throughput;
+
+/**
+ * @author Camelion
+ * @since 13.03.2018
+ * <p>
+ * Ensures that there is problem with vtables if many types inherited from one
+ * and performance will be slightly better with manual switch case
+ */
+@Fork(value = 1, jvmArgs = {"-server"/*, "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintAssembly"*/})
+@BenchmarkMode(Throughput)
+@OutputTimeUnit(MICROSECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+public class ColumnTypeBenchmarks {
+
+    private static final Unsafe U;
+    private static long integerValueFieldOffset;
+
+    static {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            U = (Unsafe) f.get(null);
+
+            integerValueFieldOffset = U.objectFieldOffset(Integer.class.getDeclaredField("value"));
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object[] data;
+    private EConsumer eConsumer;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(ColumnTypeBenchmarks.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setup() {
+        eConsumer = EConsumer.valueOf("E_CONSUMER_1");
+        data = new Object[]{10000};
+    }
+
+    @Benchmark
+    public void eConsume(Blackhole bh) {
+        eConsumer.consume(data[0], bh);
+    }
+
+    @Benchmark
+    public void tConsume(Blackhole bh) {
+        Types.tconsume(1, data[0], bh);
+    }
+
+    enum EConsumer {
+        E_CONSUMER_1 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        },
+        E_CONSUMER_2 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        }, E_CONSUMER_3 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        }, E_CONSUMER_4 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        }, E_CONSUMER_5 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        }, E_CONSUMER_6 {
+            @Override
+            void consume(Object o, Blackhole bh) {
+                bh.consume((int) o);
+            }
+        };
+
+
+        abstract void consume(Object o, Blackhole bh);
+    }
+
+    static class Types {
+        static void tconsume(int type, Object o, Blackhole bh) {
+            switch (type) {
+                case 1:
+                    consume1(o, bh);
+                    return;
+                case 2:
+                    consume2(o, bh);
+                    return;
+                case 3:
+                    consume3(o, bh);
+                    return;
+                case 4:
+                    consume4(o, bh);
+                    return;
+                case 5:
+                    consume5(o, bh);
+                    return;
+                case 6:
+                    consume6(o, bh);
+            }
+        }
+
+        static void consume1(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume2(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume3(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume4(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume5(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+
+        static void consume6(Object o, Blackhole bh) {
+            bh.consume((int) o);
+        }
+    }
+}

--- a/src/main/java/com/github/mangelion/ClickHousePacketDecoder.java
+++ b/src/main/java/com/github/mangelion/ClickHousePacketDecoder.java
@@ -62,7 +62,7 @@ final class ClickHousePacketDecoder extends ReplayingDecoder<Void> {
         ColumnWithTypeAndName[] cs = new ColumnWithTypeAndName[columns];
         for (int i = 0; i < columns; i++) {
             String columnName = readStringBinary(in);
-            int type = ColumnType.valueOf(readStringBinary(in));
+            byte type = ColumnType.valueOf(readStringBinary(in));
 
             ColumnWithTypeAndName column = cs[i] = new ColumnWithTypeAndName(type, columnName, ctx.alloc().directBuffer());
 

--- a/src/main/java/com/github/mangelion/ClickHousePacketDecoder.java
+++ b/src/main/java/com/github/mangelion/ClickHousePacketDecoder.java
@@ -62,12 +62,12 @@ final class ClickHousePacketDecoder extends ReplayingDecoder<Void> {
         ColumnWithTypeAndName[] cs = new ColumnWithTypeAndName[columns];
         for (int i = 0; i < columns; i++) {
             String columnName = readStringBinary(in);
-            ColumnType type = ColumnType.valueOf(readStringBinary(in));
+            int type = ColumnType.valueOf(readStringBinary(in));
 
             ColumnWithTypeAndName column = cs[i] = new ColumnWithTypeAndName(type, columnName, ctx.alloc().directBuffer());
 
             if (rows > 0) {
-                column.type.read(in, column, rows);
+                ColumnType.read(type, in, column.data, rows);
             }
         }
 

--- a/src/main/java/com/github/mangelion/ColumnType.java
+++ b/src/main/java/com/github/mangelion/ColumnType.java
@@ -27,126 +27,137 @@ import static java.time.temporal.ChronoField.INSTANT_SECONDS;
 
 /**
  * @author Camelion
- * @since 25.12.2017
- * <p>
- * Need to be completely redesign, because casting objects is so expensive
+ * @since 14.03.2018
  */
-enum ColumnType {
-    Int8 {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            buf.writeByte(((Number) val).byteValue());
+final class ColumnType {
+    private static final int INT_8 = 0;
+    private static final int U_INT_8 = 1;
+    private static final int INT_32 = 2;
+    private static final int U_INT_32 = 3;
+    private static final int INT_64 = 4;
+    private static final int U_INT_64 = 5;
+    private static final int STRING = 6;
+    private static final int DATE = 7;
+    private static final int DATETIME = 8;
+
+    static int valueOf(String typeName) {
+        switch (typeName) {
+            case "Int8":
+                return INT_8;
+            case "UInt8":
+                return U_INT_8;
+            case "Int32":
+                return INT_32;
+            case "UInt32":
+                return U_INT_32;
+            case "Int64":
+                return INT_64;
+            case "UInt64":
+                return U_INT_64;
+            case "String":
+                return STRING;
+            case "Date":
+                return DATE;
+            case "DateTime":
+                return DATETIME;
+            default:
+                throw new IllegalArgumentException("Can not find according type for name " + typeName);
+        }
+    }
+
+    static CharSequence valueOf(int type) {
+        switch (type) {
+            case INT_8:
+                return "Int8";
+            case U_INT_8:
+                return "UInt8";
+            case INT_32:
+                return "Int32";
+            case U_INT_32:
+                return "UInt32";
+            case INT_64:
+                return "Int64";
+            case U_INT_64:
+                return "UInt64";
+            case STRING:
+                return "String";
+            case DATE:
+                return "Date";
+            case DATETIME:
+                return "DateTime";
+            default:
+                throw new IllegalArgumentException("Can not find according name for type " + type);
+        }
+    }
+
+    static void read(int type, ByteBuf from, ByteBuf to, int count) {
+        switch (type) {
+            case INT_8:
+            case U_INT_8:
+                from.readBytes(to, count);
+                return;
+            case INT_32:
+            case U_INT_32:
+            case DATETIME:
+                from.readBytes(to, count * 4);
+                return;
+            case INT_64:
+            case U_INT_64:
+                from.readBytes(to, count * 8);
+            case STRING:
+                readString(from, to, count);
+                return;
+            case DATE:
+                from.readBytes(to, count * 2);
+                return;
+            default:
+                throw new IllegalArgumentException("Can not read unknown type " + type);
+        }
+    }
+
+    private static void readString(ByteBuf in, ByteBuf out, int count) {
+        int from = in.readerIndex();
+        in.markReaderIndex();
+        for (int i = 0; i < count; i++) {
+            int strSize = (int) readVarUInt(in);
+
+            in.readerIndex(in.readerIndex() + strSize);
         }
 
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows);
-        }
-    },
-    UInt8 {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            buf.writeByte(((Number) val).byteValue());
-        }
+        int to = in.readerIndex();
+        in.resetReaderIndex();
 
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows);
-        }
-    },
-    Int32 {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            buf.writeIntLE((Integer) val);
-        }
+        in.readBytes(out, to - from);
+    }
 
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows * 4);
+    public static <T> void write(int type, T t, ByteBuf buf) {
+        switch (type) {
+            case INT_8:
+            case U_INT_8:
+                buf.writeByte((byte) t);
+                return;
+            case INT_32:
+            case U_INT_32:
+                buf.writeIntLE((int) t);
+                return;
+            case INT_64:
+            case U_INT_64:
+                buf.writeLongLE((long) t);
+                return;
+            case STRING:
+                writeStringBinary(buf, (String) t);
+                return;
+            // possible writeShortLe and writeIntLe below
+            case DATE:
+                Temporal date = (Temporal) t;
+                buf.writeShort(date.get(EPOCH_DAY));
+                return;
+            case DATETIME:
+                Temporal dateTime = (Temporal) t;
+                buf.writeInt((int) dateTime.getLong(INSTANT_SECONDS));
+                return;
+            default:
+                throw new IllegalArgumentException("Can not write unknown type " + type);
         }
-    },
-    UInt32 {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            buf.writeIntLE((Integer) val);
-        }
-
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows * 4);
-        }
-    },
-    Int64 {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            buf.writeLongLE(((Number) val).longValue());
-        }
-
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows * 8);
-        }
-    },
-    UInt64 {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            buf.writeLongLE(((Number) val).longValue());
-        }
-
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows * 8);
-        }
-    },
-    String {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            String str = (java.lang.String) val;
-            writeStringBinary(buf, str);
-        }
-
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            int from = buf.readerIndex();
-            buf.markReaderIndex();
-            for (int i = 0; i < rows; i++) {
-                int strSize = (int) readVarUInt(buf);
-
-                buf.readerIndex(buf.readerIndex() + strSize);
-            }
-
-            int to = buf.readerIndex();
-            buf.resetReaderIndex();
-
-            buf.readBytes(column.data, to - from);
-        }
-    },
-    Date {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            Temporal dateTime = (Temporal) val;
-            buf.writeShort(dateTime.get(EPOCH_DAY));
-        }
-
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows * 2);
-        }
-    },
-    DateTime {
-        @Override
-        void write(ByteBuf buf, Object val) {
-            Temporal dateTime = (Temporal) val;
-            buf.writeInt((int) dateTime.getLong(INSTANT_SECONDS));
-        }
-
-        @Override
-        void read(ByteBuf buf, ColumnWithTypeAndName column, int rows) {
-            buf.readBytes(column.data, rows * 4);
-        }
-    };
-
-    abstract void write(ByteBuf buf, Object val);
-
-    abstract void read(ByteBuf buf, ColumnWithTypeAndName column, int rows);
+    }
 }

--- a/src/main/java/com/github/mangelion/ColumnType.java
+++ b/src/main/java/com/github/mangelion/ColumnType.java
@@ -130,30 +130,30 @@ final class ColumnType {
         in.readBytes(out, to - from);
     }
 
-    public static <T> void write(int type, T t, ByteBuf buf) {
+    public static void write(int type, Object val, ByteBuf buf) {
         switch (type) {
             case INT_8:
             case U_INT_8:
-                buf.writeByte((byte) t);
+                buf.writeByte((byte) val);
                 return;
             case INT_32:
             case U_INT_32:
-                buf.writeIntLE((int) t);
+                buf.writeIntLE((int) val);
                 return;
             case INT_64:
             case U_INT_64:
-                buf.writeLongLE((long) t);
+                buf.writeLongLE((long) val);
                 return;
             case STRING:
-                writeStringBinary(buf, (String) t);
+                writeStringBinary(buf, (String) val);
                 return;
             // possible writeShortLe and writeIntLe below
             case DATE:
-                Temporal date = (Temporal) t;
+                Temporal date = (Temporal) val;
                 buf.writeShort(date.get(EPOCH_DAY));
                 return;
             case DATETIME:
-                Temporal dateTime = (Temporal) t;
+                Temporal dateTime = (Temporal) val;
                 buf.writeInt((int) dateTime.getLong(INSTANT_SECONDS));
                 return;
             default:

--- a/src/main/java/com/github/mangelion/ColumnType.java
+++ b/src/main/java/com/github/mangelion/ColumnType.java
@@ -130,7 +130,7 @@ final class ColumnType {
         in.readBytes(out, to - from);
     }
 
-    public static void write(int type, Object val, ByteBuf buf) {
+    static void write(int type, Object val, ByteBuf buf) {
         switch (type) {
             case INT_8:
             case U_INT_8:

--- a/src/main/java/com/github/mangelion/ColumnType.java
+++ b/src/main/java/com/github/mangelion/ColumnType.java
@@ -30,17 +30,17 @@ import static java.time.temporal.ChronoField.INSTANT_SECONDS;
  * @since 14.03.2018
  */
 final class ColumnType {
-    private static final int INT_8 = 0;
-    private static final int U_INT_8 = 1;
-    private static final int INT_32 = 2;
-    private static final int U_INT_32 = 3;
-    private static final int INT_64 = 4;
-    private static final int U_INT_64 = 5;
-    private static final int STRING = 6;
-    private static final int DATE = 7;
-    private static final int DATETIME = 8;
+    private static final byte INT_8 = 0;
+    private static final byte U_INT_8 = 1;
+    private static final byte INT_32 = 2;
+    private static final byte U_INT_32 = 3;
+    private static final byte INT_64 = 4;
+    private static final byte U_INT_64 = 5;
+    private static final byte STRING = 6;
+    private static final byte DATE = 7;
+    private static final byte DATETIME = 8;
 
-    static int valueOf(String typeName) {
+    static byte valueOf(String typeName) {
         switch (typeName) {
             case "Int8":
                 return INT_8;
@@ -65,7 +65,7 @@ final class ColumnType {
         }
     }
 
-    static CharSequence valueOf(int type) {
+    static CharSequence valueOf(byte type) {
         switch (type) {
             case INT_8:
                 return "Int8";
@@ -90,7 +90,7 @@ final class ColumnType {
         }
     }
 
-    static void read(int type, ByteBuf from, ByteBuf to, int count) {
+    static void read(byte type, ByteBuf from, ByteBuf to, int count) {
         switch (type) {
             case INT_8:
             case U_INT_8:
@@ -130,7 +130,7 @@ final class ColumnType {
         in.readBytes(out, to - from);
     }
 
-    static void write(int type, Object val, ByteBuf buf) {
+    static void write(byte type, Object val, ByteBuf buf) {
         switch (type) {
             case INT_8:
             case U_INT_8:

--- a/src/main/java/com/github/mangelion/ColumnWithTypeAndName.java
+++ b/src/main/java/com/github/mangelion/ColumnWithTypeAndName.java
@@ -23,12 +23,12 @@ import io.netty.buffer.ByteBuf;
  * @since 24.12.2017
  */
 final class ColumnWithTypeAndName {
-    final ColumnType type;
+    final int type;
     final ByteBuf data;
     final String name;
 
     // todo may be lazy allocation with predefined size would be more effective
-    ColumnWithTypeAndName(ColumnType type, String name, ByteBuf data) {
+    ColumnWithTypeAndName(int type, String name, ByteBuf data) {
         this.type = type;
         this.name = name;
         this.data = data;

--- a/src/main/java/com/github/mangelion/ColumnWithTypeAndName.java
+++ b/src/main/java/com/github/mangelion/ColumnWithTypeAndName.java
@@ -23,12 +23,12 @@ import io.netty.buffer.ByteBuf;
  * @since 24.12.2017
  */
 final class ColumnWithTypeAndName {
-    final int type;
+    final byte type;
     final ByteBuf data;
     final String name;
 
     // todo may be lazy allocation with predefined size would be more effective
-    ColumnWithTypeAndName(int type, String name, ByteBuf data) {
+    ColumnWithTypeAndName(byte type, String name, ByteBuf data) {
         this.type = type;
         this.name = name;
         this.data = data;

--- a/src/main/java/com/github/mangelion/DataBlockEncoder.java
+++ b/src/main/java/com/github/mangelion/DataBlockEncoder.java
@@ -57,7 +57,7 @@ final class DataBlockEncoder extends MessageToByteEncoder<DataBlock> {
         for (int i = 0; i < columns.length; i++) {
             ColumnWithTypeAndName c = columns[i];
             writeStringBinary(out, c.name);
-            writeStringBinary(out, c.type.name());
+            writeStringBinary(out, ColumnType.valueOf(c.type));
             if (block.rows > 0) {
                 out.writeBytes(c.data);
             }

--- a/src/main/java/com/github/mangelion/ObjectsToBlockProcessor.java
+++ b/src/main/java/com/github/mangelion/ObjectsToBlockProcessor.java
@@ -161,7 +161,7 @@ final class ObjectsToBlockProcessor<T> implements Flow.Processor<T[], DataBlock>
                 if ((left = requested.decrementAndGet()) >= 0) {
                     for (int i = 0; i < columns.length; i++) {
                         ColumnWithTypeAndName c = columns[i];
-                        c.type.write(c.data, item[i]);
+                        ColumnType.write(c.type, item[i], c.data);
                     }
 
                     if (++rows >= BLOCK_SIZE) {

--- a/src/test/java/com/github/mangelion/ClickHouseClientTest.java
+++ b/src/test/java/com/github/mangelion/ClickHouseClientTest.java
@@ -20,6 +20,7 @@ import com.github.mangelion.test.extensions.docker.DockerContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.SynchronousSink;
 import reactor.test.StepVerifier;
 import ru.yandex.clickhouse.ClickHouseDataSource;
 import ru.yandex.clickhouse.ClickHouseStatement;
@@ -28,10 +29,11 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.concurrent.Flow;
+import java.util.function.Consumer;
 
 import static reactor.adapter.JdkFlowAdapter.flowPublisherToFlux;
 import static reactor.adapter.JdkFlowAdapter.publisherToFlowPublisher;
-import static reactor.core.publisher.Flux.range;
+import static reactor.core.publisher.Flux.generate;
 
 /**
  * @author Camelion
@@ -58,8 +60,8 @@ final class ClickHouseClientTest {
 
         Flow.Publisher<Void> result = client.sendData("INSERT INTO default.connection_test_uint32(value)",
                 publisherToFlowPublisher(
-                        range(0, NUMBERS_COUNT)
-                                .map(i -> data)));
+                        generate((Consumer<SynchronousSink<Object[]>>) sink -> sink.next(data))
+                                .take(NUMBERS_COUNT)));
 
         StepVerifier
                 .create(flowPublisherToFlux(result))
@@ -77,8 +79,8 @@ final class ClickHouseClientTest {
 
         Flow.Publisher<Void> result = client.sendData("INSERT INTO default.connection_test_uint32(value)",
                 publisherToFlowPublisher(
-                        range(0, NUMBERS_COUNT)
-                                .map(i -> data)));
+                        generate((Consumer<SynchronousSink<Object[]>>) sink -> sink.next(data))
+                                .take(NUMBERS_COUNT)));
 
         StepVerifier
                 .create(flowPublisherToFlux(result))
@@ -113,8 +115,8 @@ final class ClickHouseClientTest {
 
         Flow.Publisher<Void> result = client.sendData("INSERT INTO default.connection_test_uint64(value)",
                 publisherToFlowPublisher(
-                        range(0, NUMBERS_COUNT)
-                                .map(i -> data)));
+                        generate((Consumer<SynchronousSink<Object[]>>) sink -> sink.next(data))
+                                .take(NUMBERS_COUNT)));
 
         StepVerifier
                 .create(flowPublisherToFlux(result))

--- a/src/test/java/com/github/mangelion/ClickHouseClientTest.java
+++ b/src/test/java/com/github/mangelion/ClickHouseClientTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.SynchronousSink;
-import reactor.test.StepVerifier;
 import ru.yandex.clickhouse.ClickHouseDataSource;
 import ru.yandex.clickhouse.ClickHouseStatement;
 
@@ -38,6 +37,7 @@ import static reactor.core.publisher.Flux.generate;
 /**
  * @author Camelion
  * @since 11/02/2018
+ * Only comparisons test with jdbc in this class
  */
 @DockerContainer(image = "yandex/clickhouse-server", ports = {"9000:9000", "8123:8123"})
 final class ClickHouseClientTest {
@@ -63,9 +63,7 @@ final class ClickHouseClientTest {
                         generate((Consumer<SynchronousSink<Object[]>>) sink -> sink.next(data))
                                 .take(NUMBERS_COUNT)));
 
-        StepVerifier
-                .create(flowPublisherToFlux(result))
-                .verifyComplete();
+        flowPublisherToFlux(result).blockLast();
     }
 
     @Test
@@ -82,9 +80,7 @@ final class ClickHouseClientTest {
                         generate((Consumer<SynchronousSink<Object[]>>) sink -> sink.next(data))
                                 .take(NUMBERS_COUNT)));
 
-        StepVerifier
-                .create(flowPublisherToFlux(result))
-                .verifyComplete();
+        flowPublisherToFlux(result).blockLast();
     }
 
     @Test
@@ -118,9 +114,7 @@ final class ClickHouseClientTest {
                         generate((Consumer<SynchronousSink<Object[]>>) sink -> sink.next(data))
                                 .take(NUMBERS_COUNT)));
 
-        StepVerifier
-                .create(flowPublisherToFlux(result))
-                .verifyComplete();
+        flowPublisherToFlux(result).blockLast();
     }
 
     @Test


### PR DESCRIPTION
* Reduced CPU starvation in tests for more unaffected results
* Changed type id type from int to byte for less footprint

That's all shows around 15-20% performance increasing in tests (but actually it's around 5-8% with avoiding vtable lookups for types). And the rest is an invisible performance, that was hidden in tests but actually didn't slow down applications.